### PR TITLE
fix: disable base entitlements injection for notarization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ release-signed:
 		CODE_SIGN_IDENTITY="$$SIGNING_ID" \
 		CODE_SIGN_STYLE=Manual \
 		DEVELOPMENT_TEAM=6Y922224CW \
+		CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
 		OTHER_CODE_SIGN_FLAGS="--timestamp --options runtime"
 	@echo "✅ Signed build complete"
 


### PR DESCRIPTION
## Summary
Fix notarization failure by disabling base entitlements injection in release builds.

## Changes
- Add `CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO` to `release-signed` target in Makefile
- Prevents injection of `com.apple.security.get-task-allow` entitlement (debug-only)
- Allows builds to pass Apple's notarization requirements

## Testing
- ✅ Built signed DMG with new settings
- ✅ Submitted to Apple notarization service
- ✅ Notarization accepted
- ✅ Stapled ticket to DMG
- ✅ Verified with `make check-signing`

## Impact
This fix is critical for v1.1.0 release - without it, the DMG cannot be notarized and users will see Gatekeeper warnings.

## Related
- Fixes notarization failures encountered during v1.1.0 release
- Tested with submission ID: 4a82567d-a992-49f1-830e-516af208bd24 (Accepted)